### PR TITLE
Update documentation links for client libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ If you are interested in building a service using the API, there are some librar
   
 | Language | Repository |  
 | --- | --- |  
-| GoLang | https://github.com/xivapi/xivapi-go |  
+| Golang | https://github.com/xivapi/xivapi-go |  
+| Ruby | https://github.com/xivapi/xivapi-ruby |  
+| JavsScript | https://github.com/xivapi/xivapi-js |  
 | Angular | https://github.com/xivapi/angular-client |  
 | PHP (WIP) | https://github.com/xivapi/xivapi-php |  
   

--- a/templates/docs/pages/getting_started.html.twig
+++ b/templates/docs/pages/getting_started.html.twig
@@ -39,6 +39,12 @@
         <tr>
             <td>Javascript</td>
             <td>
+                <a href="https://github.com/xivapi/angular-client">https://github.com/xivapi/xivapi-js</a>
+            </td>
+        </tr>
+        <tr>
+            <td>Angular</td>
+            <td>
                 <a href="https://github.com/xivapi/angular-client">https://github.com/xivapi/angular-client</a>
             </td>
         </tr>


### PR DESCRIPTION
Theres a bunch of trailing whitespace in README but yolo. Newbie dev was getting confused by JS pointing to Angular so I updated the link and added the actual JS client. Ruby was missing in the README too.