### PR TITLE
Mend documentation change for client libraries

### DIFF
--- a/templates/docs/pages/getting_started.html.twig
+++ b/templates/docs/pages/getting_started.html.twig
@@ -39,7 +39,7 @@
         <tr>
             <td>Javascript</td>
             <td>
-                <a href="https://github.com/xivapi/angular-client">https://github.com/xivapi/xivapi-js</a>
+                <a href="https://github.com/xivapi/xivapi-js">https://github.com/xivapi/xivapi-js</a>
             </td>
         </tr>
         <tr>


### PR DESCRIPTION
The fix suggested with #7 featured a wrong URL for the JS library, so this is mended here.