### PR TITLE
Privatise the API

### DIFF
--- a/src/Exception/ApiRestrictedException.php
+++ b/src/Exception/ApiRestrictedException.php
@@ -9,5 +9,5 @@ class ApiRestrictedException extends \Exception
     use ExceptionTrait;
     
     const CODE    = 400;
-    const MESSAGE = 'Could not find a valid key in the URL request. Please check the URL you are requesting against has the key field. It should look like this: ?something=ewf&key=your_key.';
+    const MESSAGE = 'You do not have permission to use this API.';
 }

--- a/src/Service/API/ApiPermissions.php
+++ b/src/Service/API/ApiPermissions.php
@@ -12,6 +12,7 @@ class ApiPermissions
     const PERMISSION_MAPPY     = 'mappy';
     const PERMISSION_KING      = 'king';
     const PERMISSION_ADMIN     = 'admin';
+    const PERMISSION_ACCESS    = 'access';
 
     private static $permissions = [];
 

--- a/templates/account/index.html.twig
+++ b/templates/account/index.html.twig
@@ -64,6 +64,7 @@
             {# API Information #}
             <h1>API Access</h1>
             <div class="account-panel">
+                {% if auth.hasAccess %}
                 <table>
                     <tr>
                         <td width="30%">API Key</td>
@@ -162,6 +163,24 @@
                         </td>
                     </tr>
                 </table>
+                {% else %}
+                <table>
+                    <tr>
+                        <td width="30%">Information</td>
+                        <td>
+                            <p>
+                                XIVAPI is an invitation private only API.
+                            </p>
+
+                            <p>
+                                If you are interested in using the API then
+                                <a href="https://discord.gg/MFFVHWC">please jump on Discord</a> to
+                                discuss your requirements.
+                            </p>
+                        </td>
+                    </tr>
+                </table>
+                {% endif %}
             </div>
         </div>
     {% else %}

--- a/templates/docs/index.html.twig
+++ b/templates/docs/index.html.twig
@@ -13,6 +13,7 @@
                     <small>v{{ siteVersion().version }} - {{ environment() == 'staging' ? 'Staging' : 'Production' }}</small>
                 </div>
 
+                {% if auth.hasAccess %}
                 <div class="docs-links">
                     <a href="{{ path('docs_page', { page: 'Welcome' }) }}" class="{{ section != 1 ?: 'active' }}">Welcome</a>
                     <div class="sub-nav">
@@ -97,12 +98,30 @@
                     <a href="{{ path('docs_page', { page: 'Mappy-Data' }) }}" class="{{ section != 17 ?: 'active' }}">Mappy Data</a>
                     <a href="{{ path('docs_page', { page: 'Costs' }) }}" class="{{ section != 20 ?: 'active' }}">Costs</a>
                 </div>
+                {% endif %}
             </div>
         </aside>
     </div>
     <div>
         <main>
-            {% block doc %}{% endblock %}
+            {% if auth.hasAccess %}
+                {% block doc %}{% endblock %}
+            {% else %}
+
+                <h2>PRIVATE API</h2>
+
+                <p>
+                    XIVAPI is an invitation private only API.
+                </p>
+
+                <p>
+                    If you are interested in using the API then
+                    <a href="https://discord.gg/MFFVHWC">please jump on Discord</a> to
+                    discuss your requirements.
+                </p>
+
+            {% endif %}
+
         </main>
     </div>
 </div>

--- a/templates/docs/pages/character.html.twig
+++ b/templates/docs/pages/character.html.twig
@@ -33,7 +33,7 @@
     <p class="note">
         A single source (User or Developer) can <strong>add</strong> a maximum of 100 characters within a 2 hour period,
         if you spam add thousands of characters then expect them all to be deleted, if you need thousands then
-        please message Vekien in discord as a pre-warning.
+        please message the discord as a pre-warning.
         <br><br>
         Once a character is on XIVAPI this limit is not checked, it is only for the <strong>very 1st request</strong>,
         which can be done anyone (your character may already exist on the service!)

--- a/templates/docs/pages/mappy_data.html.twig
+++ b/templates/docs/pages/mappy_data.html.twig
@@ -63,13 +63,6 @@
     <hr>
 
     <p>
-        The app has the ability to submit data to XIVAPI if you have an approved dev apps key, if
-        you are interested in doing this then please contact **@vekien** on the XIVAPI discord and
-        if we need more map positions populating then you will be invited to the #beta channel
-        to join the collaboration.
-    </p>
-
-    <p>
         As map data is very static (only changes when SE change something on an update) there
         is not much reason to go back to old positions to update. The only real exception is F.A.T.Es
         where the position can only be recorded when the F.A.T.E is active.

--- a/templates/home.html.twig
+++ b/templates/home.html.twig
@@ -94,6 +94,7 @@
     </div>
 </div>
 
+{% if auth.hasAccess %}
 <div class="paymysub-section">
     <div>
         <div>
@@ -125,17 +126,14 @@
         </div>
     </div>
 </div>
-
+{% endif %}
 
 <footer>
     <div>
         <div>
-            <strong>Premium Virtue (Phoenix)</strong> <br>
-            Discord: Vekien#3458 <br>
-            Twitter: <a href="https://twitter.com/viion">@viion</a>
+            XIVAPI v{{ siteVersion().version }} - {{ siteVersion().hash_min|upper }}
         </div>
         <div>
-            v{{ siteVersion().version }} ({{ siteVersion().hash_min }}) - {{ siteVersion().commits|number_format }} changes - Deployed {{ siteVersion().time }} <br>
             ALL FINAL FANTASY XIV CONTENT IS PROPERTY OF SQUARE ENIX CO., LTD <br>
 
             {% if auth.user %}


### PR DESCRIPTION
Merge this when you want to make XIVAPI Private.

Add `access` as a permission to any user in the database, users can be found via their Discord ID once they have logged in. Permissions are comma seperated.