### PR TITLE
Make Server parameter adjust for weird casing

### DIFF
--- a/src/Controller/LodestoneCharacterController.php
+++ b/src/Controller/LodestoneCharacterController.php
@@ -27,7 +27,7 @@ class LodestoneCharacterController extends AbstractController
         return $this->json(
             (new Api())->character()->search(
                 $request->get('name'),
-                ucwords($request->get('server')),
+                ucwords(strtolower($request->get('server'))),
                 $request->get('page') ?: 1
             )
         );
@@ -42,7 +42,7 @@ class LodestoneCharacterController extends AbstractController
     {
         $ids = explode(',', $request->get('ids'));
         if (count($ids) > 512) {
-            throw new \Exception("Woah their calm down, 512+ characters wtf?");
+            throw new \Exception("Woah there calm down, 512+ characters wtf?");
         }
 
         $response = [];

--- a/src/Controller/LodestoneFreeCompanyController.php
+++ b/src/Controller/LodestoneFreeCompanyController.php
@@ -28,7 +28,7 @@ class LodestoneFreeCompanyController extends AbstractController
         return $this->json(
             (new Api())->freecompany()->search(
                 $request->get('name'),
-                ucwords($request->get('server')),
+                ucwords(strtolower($request->get('server'))),
                 $request->get('page') ?: 1
             )
         );

--- a/src/Controller/LodestoneLinkshellController.php
+++ b/src/Controller/LodestoneLinkshellController.php
@@ -26,7 +26,7 @@ class LodestoneLinkshellController extends AbstractController
         return $this->json(
             (new Api())->linkshell()->search(
                 $request->get('name'),
-                ucwords($request->get('server')),
+                ucwords(strtolower($request->get('server'))),
                 $request->get('page') ?: 1
             )
         );

--- a/src/Controller/LodestonePvPTeamController.php
+++ b/src/Controller/LodestonePvPTeamController.php
@@ -24,7 +24,7 @@ class LodestonePvPTeamController extends AbstractController
         return $this->json(
             (new Api())->pvpteam()->search(
                 $request->get('name'),
-                ucwords($request->get('server')),
+                ucwords(strtolower($request->get('server'))),
                 $request->get('page') ?: 1
             )
         );


### PR DESCRIPTION
XIVAPI can't handle people goofed up casing like https://xivapi.com/character/search?name=franz+renatus&server=baLMung

This will make the server field case-insensitive like it should be.

Also fixed the "there."