### PR TITLE
Remove outdated references from Welcome page

### DIFF
--- a/templates/docs/pages/welcome.html.twig
+++ b/templates/docs/pages/welcome.html.twig
@@ -8,8 +8,8 @@
     <p>
         XIVAPI provides a massive amount of FINAL FANTASY XIV game data in a JSON format via
         a REST API. You can fetch information on all sorts of game content that has been discovered and
-        mapped in the SaintCoinach Schema. In addition it provides Character, Free Company, Linkshell, PvPTeams,
-        Lodestone and Market Board information!
+        mapped in the SaintCoinach Schema. It also provides Character, Free Company, Linkshell,
+        and PVP Team information from the Lodestone!
     </p>
 
     <h2 id="discord">Discord</h2>
@@ -127,8 +127,8 @@
         about your usage and consider how often you really need to hit the site as well as if it's
         possible to cache/preload data.
         <br><br>
-        Game Content is very static and real-time data (eg Market/Characters) have a cache layers that
-        update in the background. Be wise with regards to your usage.
+        Game Content is very static and real-time data (e.g. Characters) makes requests directly to the Lodestone.
+        Be wise with regards to your usage.
     </p>
 
     <small>


### PR DESCRIPTION
Removes references to market board, Lodestone (news) endpoints, and Lodestone cache layer.