### PR TITLE
Removed erroneous check

### DIFF
--- a/src/EventListener/RequestListener.php
+++ b/src/EventListener/RequestListener.php
@@ -44,11 +44,6 @@ class RequestListener
             (new \Raven_Client($sentry))->install();
         }
         
-        // look for multiple ?'s
-        if (substr_count(urldecode($request->getQueryString()), '?') > 0) {
-            throw new BasicException("https://en.wikipedia.org/wiki/Query_string");
-        }
-
         // Another quick hack to convert all queries into the request object
         if ($queries = $request->query->all()) {
             foreach ($queries as $key => $value) {


### PR DESCRIPTION
Well-intentioned as it might have been, this check for "?" in the **entire** query string causes a 500 in case one of the arguments contains a "?", which is perfectly valid as per https://www.w3.org/Addressing/URL/uri-spec.txt

>   CONVENTIONAL URI ENCODING SCHEME
>   
>   Where the local naming scheme uses ASCII characters which are not
>   allowed in the URI,  these may be represented in the URL by a
>   percent sign "%" immediately followed by two hexadecimal digits
>   (0-9, A-F) giving the ISO Latin 1 code for that character.
>   Character codes other than those allowed by the syntax shall not be
>   used unencoded in a URI.

and https://tools.ietf.org/html/rfc3986#section-3.4

> The characters slash ("/") and question mark ("?") may represent data
> within the query component.  Beware that some older, erroneous

This causes issues for alle clients, notably Teamcraft:

![image](https://user-images.githubusercontent.com/163428/102876826-0eb3dc80-4446-11eb-9756-d0fd7f1c446c.png)

Universalis, which will forever show a progress indicator with no further indication as to what's going on:

![image](https://user-images.githubusercontent.com/163428/102877023-5d617680-4446-11eb-85f2-ebde72e5946d.png)

but which behind the scenes runs into this issue:

![image](https://user-images.githubusercontent.com/163428/102877035-63575780-4446-11eb-817c-d0c32080b8e9.png)

and possibly Garland Tools which seem to have added a workaround by removing all occurrences of "?" from the supplied arguments which in turn leads to wrongly reporting an empty string when the input consists only of "?":

```json
{"error":"syntax error, unexpected $end, expecting FTS_TERM or FTS_NUMB or '*'"}
```

as can be seen here: https://www.garlandtools.org/api/search.php?text=%20&lang=en

and here, respectively: https://www.garlandtools.org/api/search.php?text=ano%3Ft%3fher%20egg&lang=en

I understand the desire to point users of xivapi less familiar with URL encoding to a helpful resource, such as Wikipedia. However, it is wrong to do so at the expense of compatibility with the spec, IMHO.
As such, even though this PR removes this "feature", I is still consider it an improvement over the current behaviour until someone re-implements this without breaking the spec.

Please note, that I have not tested this locally, because I don't have a PHP development environment set up and don't plan on changing that any time soon. Obviously, if you see something wrong with this, please do not hesitate to edit this PR.