### PR TITLE
Remove kr/cn (soon) and add link to cafemaker

### DIFF
--- a/templates/docs/pages/common_features.html.twig
+++ b/templates/docs/pages/common_features.html.twig
@@ -10,7 +10,7 @@
     <p>These params work on almost every API route.</p>
 
     {{ docs.param('language', '/item/1675?language=fr', 'language') }}
-    <p>This will tell the API to handle the request and the response in the specified language.</p>
+    <p>This will tell the API to handle the request and the response in the specified language. For Chinese, please use <a href="https://github.com/thewakingsands/cafemaker/wiki">Waking Sands</a></p>
     <table class="param-table">
         <tr>
             <td width="5%">en</td>
@@ -28,14 +28,14 @@
             <td>fr</td>
             <td>French</td>
         </tr>
-        <tr>
+       {# <tr>
             <td>cn</td>
             <td>Chinese (Soon)</td>
         </tr>
         <tr>
             <td>kr</td>
             <td>Korean (Soon)</td>
-        </tr>
+        </tr> #}
     </table>
 
     <p>


### PR DESCRIPTION
Removed KR/CN coming soon notices and added a link to CN cafemaker xivapi fork.