### PR TITLE
Add page number to cache key in character search

### DIFF
--- a/src/Controller/LodestoneCharacterController.php
+++ b/src/Controller/LodestoneCharacterController.php
@@ -33,7 +33,12 @@ class LodestoneCharacterController extends AbstractController
         if (empty(trim($request->get('name')))) {
             throw new NotAcceptableHttpException('You must provide a name to search.');
         }
-        $rediskey = "lodestone_search_json_response_v6_" . preg_replace('/\s+/', '_', $request->get('name')) . $request->get('server', '');
+        $rediskey = join('', array(
+            "lodestone_search_json_response_v6_",
+            preg_replace('/\s+/', '_', $request->get('name')),
+            $request->get('server', ''),
+            $request->get('page', ''),
+        ));
         $cache = Redis::Cache()->get($rediskey, true);
 
         if ($cache) {


### PR DESCRIPTION
`/character/search` API endpoint seems to be caching responses using name and server only. Subsequent paginated requests to this endpoint hits the cache and returns cached page instead of the requested one until the cached page expires.

This PR adds page to the cache key, so page is also considered when caching search results.

Problem:

First request returns the expected result set
```
// 20211201205446
// https://xivapi.com/character/search?name=Gor&server=Exodus&page=1

{
  "Pagination": {
    "Page": 1,
    "PageNext": 2,
    "PagePrev": null,
    "PageTotal": 20,
    "Results": 50,
    "ResultsPerPage": 50,
    "ResultsTotal": 1000
  },
  "Results": [ ... ]
```

Second request specifying the identical name and server, but different page still returns previously cached page
```
// 20211201205514
// https://xivapi.com/character/search?name=Gor&server=Exodus&page=6

{
  "Pagination": {
    "Page": 1,
    "PageNext": 2,
    "PagePrev": null,
    "PageTotal": 20,
    "Results": 50,
    "ResultsPerPage": 50,
    "ResultsTotal": 1000
  },
  "Results": [ ... ]
```