### PR TITLE
Add Jan/Mar 2022 new servers to CN

### DIFF
--- a/src/Common/Game/GameServers.php
+++ b/src/Common/Game/GameServers.php
@@ -119,7 +119,12 @@ class GameServers
         'MoDuNa',
         'HaiMaoChaWu',
         'RouFengHaiWan',
-        'HuPoYuan'
+        'HuPoYuan',
+        'ShuiJingTa2',
+        'YinLeiHu2',
+        'TaiYangHaiAn2',
+        'YiXiuJiaDe2',
+        'HongChaChuan2'
     ];
 
     const LIST_DC = [
@@ -251,6 +256,13 @@ class GameServers
             'HaiMaoChaWu',
             'RouFengHaiWan',
             'HuPoYuan'
+        ],
+        '豆豆柴' => [
+            'ShuiJingTa2',
+            'YinLeiHu2',
+            'TaiYangHaiAn2',
+            'YiXiuJiaDe2',
+            'HongChaChuan2'
         ],
 
         // Korean servers don't have datacenters, so we're going to call them "Korea"


### PR DESCRIPTION
CafeMaker has only 4 servers in the PR there, but the list provided in Teamcraft discord had 5. From what I can tell from the Chinese website, there should be 5 added in sets of 2/2/1, links as below:

https://ff.web.sdo.com/web8/index.html#/newstab/newscont/335785
https://ff.web.sdo.com/web8/index.html#/newstab/newscont/336255
https://ff.web.sdo.com/web8/index.html#/newstab/newscont/337630