### PR TITLE
Update search docs to clarify ES usage

### DIFF
--- a/templates/docs/pages/search.html.twig
+++ b/templates/docs/pages/search.html.twig
@@ -35,12 +35,10 @@
 
     <h2 style="font-size: 16px;">Deprecation Notice:</h2>
     <p class="note">
-        The method of GET params (show in the table below) for search is now deprecated. While the functionality
-        will never go away and always exist in some capacity, extending filter
-        abilities is no longer supported. If you want uncapped power for search please
-        considering using ElasticSearch Payloads, view the
-        <a href="#advanced">advanced section</a>
-        for more information.
+        Search filters are now in maintenance mode. We won't be adding any additional filter abilities.
+        If you want uncapped power for searchm please considering using ElasticSearch Payloads, view the
+        <a href="#advanced">advanced section</a> for more information. Note that the majority of users
+        will <i>not</i> need this, and no support or additional docs are offered.
     </p>
 
     <table class="param-table">
@@ -70,7 +68,7 @@
             <td>
                 <p>The search algorithm to use for string matching.</p>
                 <p><strong>Default:</strong> <em>{{ search_algo_default }}</em></p>
-                <p>For more information, read: <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/term-level-queries.html">Term Level Queries</a> on ElasticSearch.</p>
+                <p>For more information, read: <a href="https://www.elastic.co/guide/en/elasticsearch/reference/6.8/term-level-queries.html>Term Level Queries</a> on ElasticSearch.</p>
                 <p><strong>Supported Algorithms</strong>:</p>
                 <table class="param-table mini-table">
                     <tr>
@@ -268,11 +266,12 @@
         As search just uses the powerful <strong>ElasticSearch</strong>, you can infact just provide
         an Elastic Search valid JSON query to the endpoint as the "body" param and it will be processed.
         This bypasses all of the normal <code>GET</code> attributes you see above <small>(excluding: indexes)</small>
-        and allows you complete control over how you build the Elastic Query.
+        and allows you complete control over how you build the Elastic Query. Be aware that we run ES 6.8, and so
+        any reference documentation you search for should reflect that as ES changes query syntax across versions.
     </p>
 
     <p>
-        You can learn more about Elastic Search queries via the <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html">Query DSL Documentation</a>
+        You can learn more about Elastic Search queries via the <a href="https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl.html">Query DSL Documentation</a>
     </p>
 
     <p>

--- a/templates/docs/pages/search.html.twig
+++ b/templates/docs/pages/search.html.twig
@@ -36,7 +36,7 @@
     <h2 style="font-size: 16px;">Deprecation Notice:</h2>
     <p class="note">
         Search filters are now in maintenance mode. We won't be adding any additional filter abilities.
-        If you want uncapped power for searchm please considering using ElasticSearch Payloads, view the
+        If you want uncapped power for search, please considering using ElasticSearch Payloads, view the
         <a href="#advanced">advanced section</a> for more information. Note that the majority of users
         will <i>not</i> need this, and no support or additional docs are offered.
     </p>

--- a/templates/docs/pages/search.html.twig
+++ b/templates/docs/pages/search.html.twig
@@ -7,7 +7,7 @@
     <h1>Search</h1>
 
     <p>
-        XIVAPI provides the ability to quickly search all game content via ElasticSearch.
+        XIVAPI provides the ability to quickly search all game content via Elasticsearch.
         This search endpoint only searches game content and not: characters, free companies,
         linkshells or pvp teams. Those have their own dedicated search endpoints as they
         relay to Lodestone.
@@ -24,7 +24,7 @@
     </p>
 
     <p>
-        Search for something! The Search is multi-content and contains combined data,
+        Search for something! The search is multi-content and contains combined data,
         this means your search request covers a vast amount of selected content
         (which you can further extend via filters) and results are combined based on best-case matching.
     </p>
@@ -36,7 +36,7 @@
     <h2 style="font-size: 16px;">Deprecation Notice:</h2>
     <p class="note">
         Search filters are now in maintenance mode. We won't be adding any additional filter abilities.
-        If you want uncapped power for search, please considering using ElasticSearch Payloads, view the
+        If you want uncapped power for search, please considering using Elasticsearch queries, view the
         <a href="#advanced">advanced section</a> for more information. Note that the majority of users
         will <i>not</i> need this, and no support or additional docs are offered.
     </p>
@@ -68,7 +68,7 @@
             <td>
                 <p>The search algorithm to use for string matching.</p>
                 <p><strong>Default:</strong> <em>{{ search_algo_default }}</em></p>
-                <p>For more information, read: <a href="https://www.elastic.co/guide/en/elasticsearch/reference/6.8/term-level-queries.html>Term Level Queries</a> on ElasticSearch.</p>
+                <p>For more information, read: <a href="https://www.elastic.co/guide/en/elasticsearch/reference/6.8/term-level-queries.html>Term Level Queries</a> on Elasticsearch.</p>
                 <p><strong>Supported Algorithms</strong>:</p>
                 <table class="param-table mini-table">
                     <tr>
@@ -219,7 +219,7 @@
             <p>
                 Search for lore! This is a special built search endpoint which searches a string through
                 various lore specific content. The endpoint has all the same features as the <code>/search</code>
-                endpoint including <strong>Advanced ElasticSearch Queries</strong>.
+                endpoint including <strong>Advanced Elasticsearch Queries</strong>.
             </p>
         </div>
     </div>
@@ -260,18 +260,18 @@
 
     <hr>
 
-    <h2 id="advanced">Advanced ElasticSearch Queries</h2>
+    <h2 id="advanced">Advanced Elasticsearch Queries</h2>
 
     <p>
-        As search just uses the powerful <strong>ElasticSearch</strong>, you can infact just provide
-        an Elastic Search valid JSON query to the endpoint as the "body" param and it will be processed.
+        As search just uses the powerful <strong>Elasticsearch</strong>, you can infact just provide
+        an Elasticsearch valid JSON query to the endpoint as the "body" param and it will be processed.
         This bypasses all of the normal <code>GET</code> attributes you see above <small>(excluding: indexes)</small>
-        and allows you complete control over how you build the Elastic Query. Be aware that we run ES 6.8, and so
+        and allows you complete control over how you build the Elastic query. Be aware that we run ES 6.8, and so
         any reference documentation you search for should reflect that as ES changes query syntax across versions.
     </p>
 
     <p>
-        You can learn more about Elastic Search queries via the <a href="https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl.html">Query DSL Documentation</a>
+        You can learn more about Elasticsearch queries via the <a href="https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl.html">Query DSL Documentation</a>
     </p>
 
     <p>
@@ -279,7 +279,7 @@
     </p>
 
     <p>
-        By simply sending a JSON payload with the ElasticSearch query in the "body" field, search will switch to
+        By simply sending a JSON payload with the Elasticsearch query in the "body" field, search will switch to
         advanced mode whenever it sees a query in the "body" field.
         You can test your DSL using the <a href="{{ path('search_playground') }}" target="_blank">Search Playground</a>.
     </p>


### PR DESCRIPTION
Basically sorts out the deprecation situation, and updates the docs to point to ES 6.8 specifically as the URLs go to 8.x which doesn't have the same syntax. Additionally sorted out some bad casing, the index server is called Elasticsearch, not ElasticSearch or Elastic Search.