### PR TITLE
6.18 server changes

### DIFF
--- a/src/Common/Game/GameServers.php
+++ b/src/Common/Game/GameServers.php
@@ -172,7 +172,9 @@ class GameServers
             'Louisoix',
             'Moogle',
             'Omega',
+            'Phantom',
             'Ragnarok',
+            'Sagittarius',
             'Spriggan',
         ],
         'Light' => [

--- a/src/Common/Game/GameServers.php
+++ b/src/Common/Game/GameServers.php
@@ -184,11 +184,11 @@ class GameServers
             'Phoenix',
             'Raiden',
             'Shiva',
-            'Zodiark',
             'Twintania',
+            'Zodiark',
         ],
 
-        // JP - Offline due to World Visit congestion issues.
+        // JP
         'Elemental' => [
             'Aegis',
             'Atomos',
@@ -230,7 +230,7 @@ class GameServers
             'Zeromus',
         ],
 
-        // Oceania
+        // OC
         'Materia' => [
             'Bismarck',
             'Ravana',

--- a/src/Common/Game/GameServers.php
+++ b/src/Common/Game/GameServers.php
@@ -196,10 +196,8 @@ class GameServers
             'Garuda',
             'Gungnir',
             'Kujata',
-            'Ramuh',
             'Tonberry',
             'Typhon',
-            'Unicorn'
         ],
         'Gaia' => [
             'Alexander',
@@ -210,22 +208,26 @@ class GameServers
             'Ridill',
             'Tiamat',
             'Ultima',
-            'Valefor',
-            'Yojimbo',
-            'Zeromus',
         ],
         'Mana' => [
             'Anima',
             'Asura',
-            'Belias',
             'Chocobo',
             'Hades',
             'Ixion',
-            'Mandragora',
             'Masamune',
             'Pandaemonium',
-            'Shinryu',
             'Titan',
+        ],
+        'Meteor' => [
+            'Belias',
+            'Mandragora',
+            'Ramuh',
+            'Shinryu',
+            'Unicorn',
+            'Valefor',
+            'Yojimbo',
+            'Zeromus',
         ],
 
         // Oceania

--- a/src/Common/Game/GameServers.php
+++ b/src/Common/Game/GameServers.php
@@ -178,9 +178,11 @@ class GameServers
             'Spriggan',
         ],
         'Light' => [
+            'Alpha',
             'Lich',
             'Odin',
             'Phoenix',
+            'Raiden',
             'Shiva',
             'Zodiark',
             'Twintania',

--- a/src/Common/Game/GameServers.php
+++ b/src/Common/Game/GameServers.php
@@ -124,7 +124,13 @@ class GameServers
         'YinLeiHu2',
         'TaiYangHaiAn2',
         'YiXiuJiaDe2',
-        'HongChaChuan2'
+        'HongChaChuan2',
+
+        // New for 6.18
+        'Alpha',
+        'Phantom',
+        'Raiden',
+        'Sagittarius',
     ];
 
     const LIST_DC = [


### PR DESCRIPTION
Add the new worlds to EU and migrate the JP ones into the 4th DC. There's a comment near the top about immutable order, this seems only used by market/companion stuff we no longer support so prob isn't necessary anymore. Looks like inner DC order does't matter so I cleaned that a little.