### PR TITLE
Fixed SaintCoinach repo URLs in repo README and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Maybe online API's are not your jam, maybe you're sick of the responses and how 
   
 | Title | URL | About |  
 | --- | --- | --- |  
-| SaintCoinach | https://github.com/ufx/SaintCoinach | The worlds best datamining tool, gets everything you'll ever need, including resources to make conspiracy theorists go crazy |  
+| SaintCoinach | https://github.com/xivapi/SaintCoinach | The worlds best datamining tool, gets everything you'll ever need, including resources to make conspiracy theorists go crazy |
 | Datamining | https://github.com/viion/ffxiv-datamining | A resource for sharing datamining information, all sorts of stuff in here. |  
 | Sapphire | https://github.com/SapphireMordred/Sapphire | FFXIV Server Emulation |  
 | Patch Extractions Archive | https://github.com/viion/ffxiv-datamining-patches | A CSV extraction of every patch since 2.0 (except 2.1... dont ask) |  

--- a/templates/docs/pages/icons.html.twig
+++ b/templates/docs/pages/icons.html.twig
@@ -35,7 +35,7 @@
         </p>
 
         <p>
-            If you need all the icons, please download: <a href="https://github.com/ufx/SaintCoinach/releases">SaintCoinach.Cmd.zip</a>,
+            If you need all the icons, please download: <a href="https://github.com/xivapi/SaintCoinach/releases">SaintCoinach.Cmd.zip</a>,
             run <code>SaintCoinach.Cmd.exe</code> and type <code>ui</code> then press enter. This will give you ALL the in-game icons.
             If you want maps then run <code>maps</code> and press enter. This will be faster and more up to date than
             getting them from XIVAPI.

--- a/templates/docs/pages/welcome.html.twig
+++ b/templates/docs/pages/welcome.html.twig
@@ -253,13 +253,13 @@
 
     {# Third party tools #}
     <h2>Saint Coinach</h2>
-    <p><a href="https://github.com/ufx/SaintCoinach">https://github.com/ufx/SaintCoinach</a></p>
+    <p><a href="https://github.com/xivapi/SaintCoinach">https://github.com/xivapi/SaintCoinach</a></p>
     <p>
         SaintCoinach is a tool that allows you to extract data from the FFXIV Game files, it can provide you with
         CSV data, Icons and Maps. It is very useful if you wish to build a FFXIV fan site or application!
     </p>
 
-    <p><a href="https://github.com/ufx/SaintCoinach/blob/master/SaintCoinach/ex.json">https://github.com/ufx/SaintCoinach/blob/master/SaintCoinach/ex.json</a></p>
+    <p><a href="https://github.com/xivapi/SaintCoinach/blob/master/SaintCoinach/ex.json">https://github.com/xivapi/SaintCoinach/blob/master/SaintCoinach/ex.json</a></p>
     <p>
         The schema is a huge JSON file that describes the EXD files found in
         the FFXIV game files. Many community members take time to datamine


### PR DESCRIPTION
As tittle says, fixes SC's repo URLs in the README and other documentation files